### PR TITLE
Fixed some broken API commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,14 @@ Simple mobile optimized UI
 _ _ _ 
 ### API: ####
 
-All API calls except `/tv/<ip_address>/action` are GET
+Most API calls are GET except
+
+*  `/tv/<ip_address>/action`
+*  `/tv/<ip_address>/volume/plus`
+*  `/tv/<ip_address>/volume/minus`
+*  `/tv/<ip_address>/volume/mute`
+
+Which are POST
 
 #### Using: ####
 

--- a/server/api.js
+++ b/server/api.js
@@ -10,17 +10,17 @@
       res.end();
     });
 
-    vieraControl.get('/tv/:ip/:ip/menu', function(req, res) {
+    vieraControl.get('/tv/:ip/menu', function(req, res) {
       sendRequest(req.params.ip, 'command', 'X_SendKey', '<X_KeyEvent>NRC_MENU-ONOFF</X_KeyEvent>');
       res.end();
     });
 
-    vieraControl.get('/tv/:ip/:ip/3d', function(req, res) {
+    vieraControl.get('/tv/:ip/3d', function(req, res) {
       sendRequest(req.params.ip, 'command', 'X_SendKey', '<X_KeyEvent>NRC_3D-ONOFF</X_KeyEvent>');
       res.end();
     });
 
-    vieraControl.get('/tv/:ip/:ip/ok', function(req, res) {
+    vieraControl.get('/tv/:ip/ok', function(req, res) {
       sendRequest(req.params.ip, 'command', 'X_SendKey', '<X_KeyEvent>NRC_ENTER-ONOFF</X_KeyEvent>');
       res.end();
     });
@@ -113,7 +113,7 @@
       res.end();
     });
 
-    vieraControl.get('/tv/:ip/volume/mute', function(req, res) {
+    vieraControl.post('/tv/:ip/volume/mute', function(req, res) {
       sendRequest(req.params.ip, 'command', 'X_SendKey', '<X_KeyEvent>NRC_MUTE-ONOFF</X_KeyEvent>');
       res.end();
     });


### PR DESCRIPTION
It looks like the volume mute commands wasn't working because /volume/:vol was being greedy and swallowing them all, so I changed it to POST and corrected the readme to say this and the other volume commands were POST.
Others appeared to not be working because they had the IP repeated in their URL segments.